### PR TITLE
 If the user desires , you want to capture a column of type TEXT as a String

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -6,5 +6,6 @@ requires 'DBD::mysql';
 on 'test' => sub {
     requires 'Test::More', '0.98';
     requires 'Test::Fatal';
+    requires 'Test::mysqld';
 };
 

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -36,6 +36,8 @@ DISTRIBUTIONS
       Module::Build 0.40
       Module::Build::Pluggable 0
       Module::Build::Pluggable::CPANfile 0.05
+      Test::More 0.88
+      YAML 0
       perl 5.008005
   Config-Simple-4.58
     pathname: S/SH/SHERZODR/Config-Simple-4.58.tar.gz
@@ -203,6 +205,14 @@ DISTRIBUTIONS
       File::Spec 0
       strict 0
       warnings 0
+  File-Copy-Recursive-0.38
+    pathname: D/DM/DMUEY/File-Copy-Recursive-0.38.tar.gz
+    provides:
+      File::Copy::Recursive 0.38
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Copy 0
+      File::Spec 0
   Hash-Merge-0.200
     pathname: R/RE/REHSACK/Hash-Merge-0.200.tar.gz
     provides:
@@ -368,6 +378,18 @@ DISTRIBUTIONS
       Test::More 0
       Test::NoWarnings 0.02
       Test::Tester 0.04
+  Test-Fatal-0.014
+    pathname: R/RJ/RJBS/Test-Fatal-0.014.tar.gz
+    provides:
+      Test::Fatal 0.014
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      Test::Builder 0
+      Try::Tiny 0.07
+      strict 0
+      warnings 0
   Test-Harness-3.34
     pathname: L/LE/LEONT/Test-Harness-3.34.tar.gz
     provides:
@@ -457,3 +479,55 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       Test::Builder 0
+  Test-mysqld-0.17
+    pathname: K/KA/KAZUHO/Test-mysqld-0.17.tar.gz
+    provides:
+      Test::mysqld 0.17
+    requirements:
+      Class::Accessor::Lite 0
+      DBD::mysql 0
+      DBI 0
+      ExtUtils::MakeMaker 6.42
+      File::Copy::Recursive 0
+      Test::SharedFork 0.06
+      perl 5.008
+  Try-Tiny-0.24
+    pathname: E/ET/ETHER/Try-Tiny-0.24.tar.gz
+    provides:
+      Try::Tiny 0.24
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      constant 0
+      perl 5.006
+      strict 0
+      warnings 0
+  YAML-1.15
+    pathname: I/IN/INGY/YAML-1.15.tar.gz
+    provides:
+      YAML 1.15
+      YAML::Any 1.15
+      YAML::Dumper undef
+      YAML::Dumper::Base undef
+      YAML::Error undef
+      YAML::Loader undef
+      YAML::Loader::Base undef
+      YAML::Marshall undef
+      YAML::Mo 0.88
+      YAML::Node undef
+      YAML::Tag undef
+      YAML::Type::blessed undef
+      YAML::Type::code undef
+      YAML::Type::glob undef
+      YAML::Type::ref undef
+      YAML::Type::regexp undef
+      YAML::Type::undef undef
+      YAML::Types undef
+      YAML::Warning undef
+      yaml_mapping undef
+      yaml_scalar undef
+      yaml_sequence undef
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.008001

--- a/script/mysqlbq
+++ b/script/mysqlbq
@@ -24,21 +24,22 @@ defined RC->{'client.password'} or pod2usage(2);
 my %opt;
 GetOptions(
     \%opt,
-    qw(db_host=s src=s dst=s dryrun)
+    qw(db_host=s src=s dst=s allow_text_type dryrun)
 ) or pod2usage(2);
 
 my @required_options = qw(db_host src dst);
 pod2usage(2) if grep {!exists $opt{$_}} @required_options;
 
 my $app = App::BigQuery::Importer::MySQL->new({
-    dryrun        => $opt{dryrun},
-    src           => $opt{src},
-    dst           => $opt{dst},
-    mysqlhost     => $opt{db_host},
-    mysqluser     => RC->{'client.user'},
-    mysqlpassword => RC->{'client.password'},
-    project_id    => RC->{'default.project_id'},
-    progs         => $pathes,
+    dryrun          => $opt{dryrun},
+    src             => $opt{src},
+    dst             => $opt{dst},
+    allow_text_type => $opt{allow_text_type},
+    mysqlhost       => $opt{db_host},
+    mysqluser       => RC->{'client.user'},
+    mysqlpassword   => RC->{'client.password'},
+    project_id      => RC->{'default.project_id'},
+    progs           => $pathes,
 });
 $app->run;
 
@@ -53,10 +54,11 @@ mysqlbq - cli tool for App::BigQuery::Importer::MySQL
     mysqlbq - command description
       Usage: command [options]
       Options:
-        --db_host   MySQL Hostname or IP addr(ex: localhost)
-        --src       MySQL Schema and Table name(ex: schema_name.table_name)
-        --dst       BigQuery Dataset and Table name(ex: dataset_name.table_name)
-        --dryrun    dry run mode. not run the side-effects operation.(ex: gsutil mk/rm, bq load/rm)
+        --db_host         MySQL Hostname or IP addr(ex: localhost)
+        --src             MySQL Schema and Table name(ex: schema_name.table_name)
+        --dst             BigQuery Dataset and Table name(ex: dataset_name.table_name)
+        --allow_text_type Import MySQL TEXT type columns to BigQuery as STRING type
+        --dryrun          dry run mode. not run the side-effects operation.(ex: gsutil mk/rm, bq load/rm)
         -h(--help)  show this help
       Requirement Programs: mysql cli and gcloud package
       Requirement Files: this script needs ~/.my.cnf and ~/.bigqueryrc files

--- a/t/01_new.t
+++ b/t/01_new.t
@@ -5,13 +5,14 @@ use Test::Fatal;
 use App::BigQuery::Importer::MySQL;
 
 our $origin_args = {
-    src           => 'src.table',
-    dst           => 'dst.table',
-    mysqlhost     => 'localhost',
-    mysqluser     => 'user',
-    mysqlpassword => 'pass',
-    project_id    => 'pjid',
-    progs         => {
+    src             => 'src.table',
+    dst             => 'dst.table',
+    allow_text_type => 0,
+    mysqlhost       => 'localhost',
+    mysqluser       => 'user',
+    mysqlpassword   => 'pass',
+    project_id      => 'pjid',
+    progs           => {
         mysql  => '/path/to/mysql',
         gsutil => '/path/to/gsutil',
         bq     => '/path/to/bq',

--- a/t/02__check_columns.t
+++ b/t/02__check_columns.t
@@ -1,0 +1,139 @@
+use strict;
+use Test::More 0.98;
+use Test::Fatal;
+use t::Util;
+
+use DBI;
+use App::BigQuery::Importer::MySQL;
+
+my $mysqld = t::Util->start_mysqld;
+my $dbh = DBI->connect($mysqld->dsn);
+
+my @create_sqls = (
+    q{
+        CREATE TABLE `test_blob` (
+          `id` integer unsigned NOT NULL auto_increment,
+          `test_blob` blob NOT NULL,
+          PRIMARY KEY (`id`)
+        );
+    },
+    q{
+        CREATE TABLE `test_text` (
+          `id` integer unsigned NOT NULL auto_increment,
+          `test_text` TEXT NOT NULL,
+          PRIMARY KEY (`id`)
+        );
+    },
+    q{
+        CREATE TABLE `test_blob_and_text` (
+          `id` integer unsigned NOT NULL auto_increment,
+          `test_blob` blob NOT NULL,
+            `test_text` TEXT NOT NULL,
+          PRIMARY KEY (`id`)
+        );
+    },
+    q{
+        CREATE TABLE `test_no_blob_and_no_text` (
+          `id` integer unsigned NOT NULL auto_increment,
+          PRIMARY KEY (`id`)
+        );
+    },
+);
+
+$dbh->do($_) for @create_sqls;
+
+subtest 'no allow_text_type' => sub {
+    like exception {
+        App::BigQuery::Importer::MySQL->_check_columns(
+            +{
+                dbh             => $dbh,
+                src_schema      => 'test',
+                src_table       => 'test_blob',
+                allow_text_type => 0,
+            }
+        );
+    }, qr/test\.test_blob has BLOB table/, "throws ok";
+
+    like exception {
+        App::BigQuery::Importer::MySQL->_check_columns(
+            +{
+                dbh             => $dbh,
+                src_schema      => 'test',
+                src_table       => 'test_text',
+                allow_text_type => 0,
+            }
+        );
+    }, qr/test\.test_text has TEXT table/, "check ok";
+
+    like exception {
+        App::BigQuery::Importer::MySQL->_check_columns(
+            +{
+                dbh             => $dbh,
+                src_schema      => 'test',
+                src_table       => 'test_blob_and_text',
+                allow_text_type => 0,
+            }
+        );
+    }, qr/test\.test_blob_and_text has BLOB table/, "throws ok";
+
+    is exception {
+        App::BigQuery::Importer::MySQL->_check_columns(
+            +{
+                dbh             => $dbh,
+                src_schema      => 'test',
+                src_table       => 'test_no_blob_and_no_text',
+                allow_text_type => 0,
+            }
+        );
+    }, undef, "check ok";
+};
+
+subtest 'allow_text_type' => sub {
+    like exception {
+        App::BigQuery::Importer::MySQL->_check_columns(
+            +{
+                dbh             => $dbh,
+                src_schema      => 'test',
+                src_table       => 'test_blob',
+                allow_text_type => 1,
+            }
+        );
+    }, qr/test\.test_blob has BLOB table/, "throws ok";
+
+    is exception {
+        App::BigQuery::Importer::MySQL->_check_columns(
+            +{
+                dbh             => $dbh,
+                src_schema      => 'test',
+                src_table       => 'test_text',
+                allow_text_type => 1,
+            }
+        );
+    }, undef, "check ok";
+
+    like exception {
+        App::BigQuery::Importer::MySQL->_check_columns(
+            +{
+                dbh             => $dbh,
+                src_schema      => 'test',
+                src_table       => 'test_blob_and_text',
+                allow_text_type => 1,
+            }
+        );
+    }, qr/test\.test_blob_and_text has BLOB table/, "throws ok";
+
+    is exception {
+        App::BigQuery::Importer::MySQL->_check_columns(
+            +{
+                dbh             => $dbh,
+                src_schema      => 'test',
+                src_table       => 'test_no_blob_and_no_text',
+                allow_text_type => 1,
+            }
+        );
+    }, undef, "check ok";
+};
+
+
+
+done_testing;

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -1,0 +1,22 @@
+package t::Util;
+use strict;
+use warnings;
+use utf8;
+
+use Test::More 0.98;
+use Test::mysqld;
+
+sub start_mysqld {
+    eval {
+        require Test::mysqld;
+        Test::mysqld->new(
+             my_cnf => {
+                 'skip-networking' => '', # no TCP socket
+             }
+         ) or die $Test::mysqld::errstr;
+    } or plan(skip_all => 'mysql-server is required to this test');
+}
+
+1;
+__END__
+


### PR DESCRIPTION
If user want to import a table that contains a TEXT type table , in the current version , it is not possible to use this module .
I think that it should be possible, if the user wishes.

Add allow_text_type option.
When this option is enable, TEXT type columns also import as string.
